### PR TITLE
Remove manual shift add form from dashboard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,6 @@ import { differenceInCalendarDays, format } from "date-fns"
 import { es } from "date-fns/locale"
 import type { ShiftEvent, ShiftType } from "@/types/shifts"
 import EditShiftModal from "@/components/EditShiftModal"
-import AddShiftForm from "@/components/AddShiftForm"
 import type { ManualRotationDay } from "@/components/ManualRotationBuilder"
 import ShiftPlannerLab from "@/components/ShiftPlannerLab"
 import DashboardSidebar from "@/components/dashboard/DashboardSidebar"
@@ -637,11 +636,6 @@ export default function Home() {
                     errorMessage={rotationError}
                   />
 
-                  <AddShiftForm
-                    onAdd={handleAddShift}
-                    selectedDate={selectedDateFromCalendar}
-                    onDateConsumed={() => setSelectedDateFromCalendar(null)}
-                  />
                 </section>
               </div>
 
@@ -769,11 +763,6 @@ export default function Home() {
                         onCommit={handleManualRotationConfirm}
                         isCommitting={isCommittingRotation}
                         errorMessage={rotationError}
-                      />
-                      <AddShiftForm
-                        onAdd={handleAddShift}
-                        selectedDate={selectedDateFromCalendar}
-                        onDateConsumed={() => setSelectedDateFromCalendar(null)}
                       />
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- remove the manual shift form from the dashboard page on both desktop and mobile views

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e416803624833288ca0667e319b391