### PR TITLE
Defer manual rotation commit callback

### DIFF
--- a/src/components/ShiftPlannerLab.tsx
+++ b/src/components/ShiftPlannerLab.tsx
@@ -177,7 +177,7 @@ export default function ShiftPlannerLab({
       }))
       .sort((a, b) => a.date.localeCompare(b.date))
 
-    void Promise.resolve(callback(payload))
+    void Promise.resolve().then(() => callback(payload))
   }, [])
 
   const updateEntries = useCallback(


### PR DESCRIPTION
## Summary
- defer the shift planner commit callback to the microtask queue so parent updates happen outside render

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e59409021c8332ad5659c83eee4e9d