### PR TITLE
Handle missing calendar ids during session restore

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,7 +41,9 @@ function toPositiveInteger(value: unknown): number | null {
       ? value
       : typeof value === "string"
         ? Number.parseInt(value, 10)
-        : Number.NaN
+        : typeof value === "bigint"
+          ? Number(value)
+          : Number.NaN
 
   if (!Number.isFinite(numericValue)) {
     return null
@@ -61,12 +63,18 @@ function sanitizeUserSummary(value: unknown): UserSummary | null {
   }
 
   const candidate = value as Partial<UserSummary>
-  const id = toPositiveInteger(candidate.id)
-  const calendarId = toPositiveInteger(candidate.calendarId)
+  const id = toPositiveInteger(
+    candidate.id ?? (candidate as { userId?: unknown }).userId
+  )
 
-  if (!id || !calendarId) {
+  if (!id) {
     return null
   }
+
+  const calendarId =
+    toPositiveInteger(
+      candidate.calendarId ?? (candidate as { calendar_id?: unknown }).calendar_id
+    ) ?? id
 
   const name =
     typeof candidate.name === "string" && candidate.name.trim().length > 0


### PR DESCRIPTION
## Summary
- relax the front-end sanitization for user summaries so bigint identifiers and alternative field names are accepted
- fall back to the user id when the calendar id is missing to avoid spurious session reset errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e59bf363fc8332892379ed0e385e13