### PR TITLE
Handle Supabase UUID user identifiers

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: Request) {
       )
     }
 
-    const userId = Number(userRow.id)
+    const userId = String(userRow.id)
     const calendarId = await getOrCreateCalendarForUser(userId)
 
     if (!calendarId) {

--- a/src/app/api/shifts/[id]/route.ts
+++ b/src/app/api/shifts/[id]/route.ts
@@ -35,15 +35,17 @@ function parseId(idParam: string): number | null {
   return id
 }
 
-function parseUserId(param: string | null): number | null {
-  if (!param) {
+function normalizeUserId(param: string | null): string | null {
+  if (typeof param !== "string") {
     return null
   }
-  const userId = Number.parseInt(param, 10)
-  if (Number.isNaN(userId) || userId <= 0) {
-    return null
+
+  const trimmed = param.trim()
+  if (trimmed.length > 0) {
+    return trimmed
   }
-  return userId
+
+  return null
 }
 
 export async function PATCH(request: NextRequest, { params }: Params) {
@@ -77,7 +79,7 @@ export async function PATCH(request: NextRequest, { params }: Params) {
       )
     }
 
-    const userId = parseUserId(request.nextUrl.searchParams.get("userId"))
+    const userId = normalizeUserId(request.nextUrl.searchParams.get("userId"))
     const calendarId = userId
       ? (await findCalendarIdForUser(userId)) ?? getFallbackCalendarId()
       : getFallbackCalendarId()
@@ -285,7 +287,7 @@ export async function DELETE(request: NextRequest, { params }: Params) {
   }
 
   try {
-    const userId = parseUserId(request.nextUrl.searchParams.get("userId"))
+    const userId = normalizeUserId(request.nextUrl.searchParams.get("userId"))
     const calendarId = userId
       ? (await findCalendarIdForUser(userId)) ?? getFallbackCalendarId()
       : getFallbackCalendarId()

--- a/src/types/users.ts
+++ b/src/types/users.ts
@@ -1,6 +1,6 @@
 export type UserSummary = {
-  id: number
+  id: string
   name: string
   email: string
-  calendarId: number
+  calendarId: number | null
 }


### PR DESCRIPTION
## Summary
- update Supabase calendar helpers and shift API routes to accept sanitized string user identifiers
- adapt user listing, authentication, and rotation generation endpoints to propagate UUID values safely
- adjust dashboard user handling to persist string IDs and optional calendar references

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e59da434d88332b6b2e8b3f7eb2548