### PR TITLE
Fix user sorting for string ids

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -767,7 +767,7 @@ export default function Home() {
 
     setUsers((current) => {
       const filtered = current.filter((item) => item.id !== sanitized.id)
-      return [...filtered, sanitized].sort((a, b) => a.id - b.id)
+      return [...filtered, sanitized].sort((a, b) => a.id.localeCompare(b.id))
     })
   }, [])
 


### PR DESCRIPTION
## Summary
- ensure the user list sorting uses string comparison so TypeScript is satisfied when IDs are strings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5a0ed1b3c8332b079c2f093bb6ab4