### PR TITLE
Fix shift API route context params type

### DIFF
--- a/src/app/api/shifts/[id]/route.ts
+++ b/src/app/api/shifts/[id]/route.ts
@@ -15,7 +15,7 @@ import { findCalendarIdForUser } from "@/lib/calendars"
 export const runtime = "nodejs"
 
 type Params = {
-  params: Promise<{ id: string }>
+  params: { id: string }
 }
 
 const DEFAULT_CALENDAR_ID = Number.parseInt(
@@ -49,8 +49,7 @@ function normalizeUserId(param: string | null): string | null {
 }
 
 export async function PATCH(request: NextRequest, context: Params) {
-  const params = await context.params
-  const id = parseId(params.id)
+  const id = parseId(context.params.id)
   if (!id) {
     return NextResponse.json(
       { error: "El identificador del turno no es válido" },
@@ -279,8 +278,7 @@ export async function PATCH(request: NextRequest, context: Params) {
 }
 
 export async function DELETE(request: NextRequest, context: Params) {
-  const params = await context.params
-  const id = parseId(params.id)
+  const id = parseId(context.params.id)
   if (!id) {
     return NextResponse.json(
       { error: "El identificador del turno no es válido" },


### PR DESCRIPTION
## Summary
- align the shift API route context type with Next.js expectations by using a synchronous params object
- reference the parsed id directly from the context params in PATCH and DELETE handlers

## Testing
- npm run build *(fails: Module not found: Can't resolve '@supabase/supabase-js')*

------
https://chatgpt.com/codex/tasks/task_e_68e5a6d9a0c88332a41d190aca36f489